### PR TITLE
fix: refresh memoized system prompts after promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ruby-3.4.5
+          ruby-version: ruby-3.3
           bundler-cache: true
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby-3.3
-          bundler-cache: true
+
+      - name: Install gems
+        run: bundle install --jobs 4 --retry 3
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Lint code for consistent style
         run: bin/rubocop -f github
+
+      - name: Run RSpec test suite
+        run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/dummy/log
 spec/dummy/log/*.log
 spec/dummy/db/*.sqlite3
 *.gem
+/vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,11 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+AllCops:
+  TargetRubyVersion: 3.3
+
 # Overwrite or add rules to create your own house style
 #
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+# Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
+Layout/SpaceInsideArrayLiteralBrackets:
+  EnforcedStyle: no_space

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem "puma"
 
-gem "sqlite3"
+gem "sqlite3", "~> 2.7"
 
 # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
 gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,14 +324,14 @@ GEM
     securerandom (0.4.1)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)
-    sqlite3 (2.7.4-aarch64-linux-gnu)
-    sqlite3 (2.7.4-aarch64-linux-musl)
-    sqlite3 (2.7.4-arm-linux-gnu)
-    sqlite3 (2.7.4-arm-linux-musl)
-    sqlite3 (2.7.4-arm64-darwin)
-    sqlite3 (2.7.4-x86_64-darwin)
-    sqlite3 (2.7.4-x86_64-linux-gnu)
-    sqlite3 (2.7.4-x86_64-linux-musl)
+    sqlite3 (2.9.0-aarch64-linux-gnu)
+    sqlite3 (2.9.0-aarch64-linux-musl)
+    sqlite3 (2.9.0-arm-linux-gnu)
+    sqlite3 (2.9.0-arm-linux-musl)
+    sqlite3 (2.9.0-arm64-darwin)
+    sqlite3 (2.9.0-x86_64-darwin)
+    sqlite3 (2.9.0-x86_64-linux-gnu)
+    sqlite3 (2.9.0-x86_64-linux-musl)
     stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.4)
@@ -374,7 +374,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubyllm-observ!
   shoulda-matchers (~> 6.0)
-  sqlite3
+  sqlite3 (~> 2.7)
   turbo-rails (~> 2.0)
 
 BUNDLED WITH

--- a/app/controllers/observ/annotations_controller.rb
+++ b/app/controllers/observ/annotations_controller.rb
@@ -1,6 +1,6 @@
 module Observ
   class AnnotationsController < ApplicationController
-    before_action :set_annotatable, except: [ :sessions_index, :traces_index, :export ]
+    before_action :set_annotatable, except: [:sessions_index, :traces_index, :export]
 
   def index
     @annotations = @annotatable.annotations
@@ -126,7 +126,7 @@ module Observ
 
   def generate_csv(annotations)
     CSV.generate(headers: true) do |csv|
-      csv << [ "ID", "Content", "Annotatable Type", "Annotatable ID", "Created At", "Updated At" ]
+      csv << ["ID", "Content", "Annotatable Type", "Annotatable ID", "Created At", "Updated At"]
 
       annotations.each do |annotation|
         csv << [

--- a/app/controllers/observ/chats_controller.rb
+++ b/app/controllers/observ/chats_controller.rb
@@ -1,6 +1,6 @@
 module Observ
   class ChatsController < ApplicationController
-    before_action :set_chat, only: [ :show ]
+    before_action :set_chat, only: [:show]
 
     def index
       @chats = ::Chat.order(created_at: :desc)

--- a/app/controllers/observ/dataset_items_controller.rb
+++ b/app/controllers/observ/dataset_items_controller.rb
@@ -3,7 +3,7 @@
 module Observ
   class DatasetItemsController < ApplicationController
     before_action :set_dataset
-    before_action :set_item, only: [ :edit, :update, :destroy ]
+    before_action :set_item, only: [:edit, :update, :destroy]
 
     def index
       @items = @dataset.items.order(created_at: :desc)

--- a/app/controllers/observ/dataset_runs_controller.rb
+++ b/app/controllers/observ/dataset_runs_controller.rb
@@ -3,7 +3,7 @@
 module Observ
   class DatasetRunsController < ApplicationController
     before_action :set_dataset
-    before_action :set_run, only: [ :show, :destroy, :run_evaluators, :review ]
+    before_action :set_run, only: [:show, :destroy, :run_evaluators, :review]
 
     def index
       @runs = @dataset.runs.order(created_at: :desc)
@@ -52,7 +52,7 @@ module Observ
     end
 
     def run_evaluators
-      evaluator_configs = @dataset.metadata&.dig("evaluators") || [ { "type" => "exact_match" } ]
+      evaluator_configs = @dataset.metadata&.dig("evaluators") || [{ "type" => "exact_match" }]
       Observ::EvaluatorRunnerService.new(@run, evaluator_configs: evaluator_configs).call
 
       redirect_to dataset_run_path(@dataset, @run),

--- a/app/controllers/observ/datasets_controller.rb
+++ b/app/controllers/observ/datasets_controller.rb
@@ -2,7 +2,7 @@
 
 module Observ
   class DatasetsController < ApplicationController
-    before_action :set_dataset, only: [ :show, :edit, :update, :destroy ]
+    before_action :set_dataset, only: [:show, :edit, :update, :destroy]
 
     def index
       @datasets = Observ::Dataset.order(updated_at: :desc)
@@ -67,7 +67,7 @@ module Observ
 
     def available_agents
       Observ::AgentProvider.all_agents.map do |agent|
-        [ agent.display_name, agent.name ]
+        [agent.display_name, agent.name]
       end
     end
   end

--- a/app/controllers/observ/prompts_controller.rb
+++ b/app/controllers/observ/prompts_controller.rb
@@ -1,7 +1,7 @@
 module Observ
   class PromptsController < ApplicationController
-    before_action :set_prompt_name, only: [ :show, :edit, :update, :destroy, :versions, :compare ]
-    before_action :set_prompt, only: [ :edit, :update, :destroy ]
+    before_action :set_prompt_name, only: [:show, :edit, :update, :destroy, :versions, :compare]
+    before_action :set_prompt, only: [:edit, :update, :destroy]
 
     # GET /observ/prompts
     def index
@@ -141,7 +141,7 @@ module Observ
       respond_to do |format|
         format.html # Render the HTML view
         format.json do
-          render json: @versions.as_json(only: [ :version, :state, :commit_message, :created_at ])
+          render json: @versions.as_json(only: [:version, :state, :commit_message, :created_at])
         end
       end
     end

--- a/app/controllers/observ/review_queue_controller.rb
+++ b/app/controllers/observ/review_queue_controller.rb
@@ -2,7 +2,7 @@
 
 module Observ
   class ReviewQueueController < ApplicationController
-    before_action :set_review_item, only: [ :show, :complete, :skip ]
+    before_action :set_review_item, only: [:show, :complete, :skip]
 
     def index
       @review_items = Observ::ReviewItem

--- a/app/helpers/observ/dashboard_helper.rb
+++ b/app/helpers/observ/dashboard_helper.rb
@@ -118,7 +118,7 @@ module Observ
     def render_json_viewer(data, compact: false)
       return "" if data.nil?
 
-      css_classes = [ "observ-json-viewer" ]
+      css_classes = ["observ-json-viewer"]
       css_classes << "observ-json-viewer--compact" if compact
 
       content_tag(:div,
@@ -146,7 +146,7 @@ module Observ
       end
 
       # Display as plain text
-      css_classes = [ "observ-code-block" ]
+      css_classes = ["observ-code-block"]
       css_classes << "observ-code-block--compact" if compact
       content_tag(:pre, content, class: css_classes.join(" "))
     end

--- a/app/helpers/observ/pagination_helper.rb
+++ b/app/helpers/observ/pagination_helper.rb
@@ -21,7 +21,7 @@ module Observ
       return "" if collection.total_count.zero?
 
       from = collection.offset_value + 1
-      to = [ collection.offset_value + collection.limit_value, collection.total_count ].min
+      to = [collection.offset_value + collection.limit_value, collection.total_count].min
       total = collection.total_count
 
       content_tag(:div, class: "observ-pagination__info") do

--- a/app/helpers/observ/prompts_helper.rb
+++ b/app/helpers/observ/prompts_helper.rb
@@ -13,7 +13,7 @@ module Observ
         .map do |provider, models|
           [
             provider.titleize,
-            models.sort_by(&:display_name).map { |m| [ m.display_name, m.id ] }
+            models.sort_by(&:display_name).map { |m| [m.display_name, m.id] }
           ]
         end
     rescue StandardError => e

--- a/app/models/concerns/observ/prompt_management.rb
+++ b/app/models/concerns/observ/prompt_management.rb
@@ -135,6 +135,15 @@ module Observ
 
       # Override system_prompt to use prompt management
       def system_prompt
+        config = prompt_config.presence || {}
+        prompt_name = config[:prompt_name] || default_prompt_name
+        current_stamp = Observ::PromptManager.cache_stamp(name: prompt_name)
+
+        if defined?(@_prompt_cache_stamp) && @_prompt_cache_stamp != current_stamp
+          reset_prompt_cache!
+        end
+
+        @_prompt_cache_stamp = current_stamp
         @_system_prompt ||= fetch_prompt(variables: prompt_variables)
       end
 
@@ -159,6 +168,7 @@ module Observ
       def reset_prompt_cache!
         @_system_prompt = nil
         @_prompt_template = nil
+        @_prompt_cache_stamp = nil
       end
 
       # Override model to check prompt metadata first

--- a/app/models/observ/prompt.rb
+++ b/app/models/observ/prompt.rb
@@ -101,7 +101,7 @@ module Observ
 
     def self.clear_cache(name:)
       # Clear all cache keys for this prompt
-      [ :draft, :production, :archived ].each do |state|
+      [:draft, :production, :archived].each do |state|
         Rails.cache.delete(cache_key_for(name: name, version: nil, state: state))
       end
     end
@@ -206,7 +206,7 @@ module Observ
 
     # Export
     def to_json_export
-      as_json(except: [ :id, :created_at, :updated_at ])
+      as_json(except: [:id, :created_at, :updated_at])
     end
 
     def to_yaml_export

--- a/app/models/observ/review_item.rb
+++ b/app/models/observ/review_item.rb
@@ -12,7 +12,7 @@ module Observ
     validates :reviewable, presence: true
     validates :reviewable_id, uniqueness: { scope: :reviewable_type }
 
-    scope :actionable, -> { where(status: [ :pending, :in_progress ]) }
+    scope :actionable, -> { where(status: [:pending, :in_progress]) }
     scope :by_priority, -> { order(priority: :desc, created_at: :asc) }
     scope :sessions, -> { where(reviewable_type: "Observ::Session") }
     scope :traces, -> { where(reviewable_type: "Observ::Trace") }

--- a/app/models/observ/score.rb
+++ b/app/models/observ/score.rb
@@ -13,7 +13,7 @@ module Observ
     validates :name, presence: true
     validates :value, presence: true, numericality: true
     validates :scoreable_id, uniqueness: {
-      scope: [ :scoreable_type, :name, :source ],
+      scope: [:scoreable_type, :name, :source],
       message: "already has a score with this name and source"
     }
 

--- a/app/presenters/observ/agent_select_presenter.rb
+++ b/app/presenters/observ/agent_select_presenter.rb
@@ -31,7 +31,7 @@ module Observ
     # Format: [[display_name, identifier], ...]
     # @return [Array<Array<String>>] options array for select dropdown
     def options
-      [ default_option ] + agent_options
+      [default_option] + agent_options
     end
 
     # Convenience class method that injects agents from Observ::AgentProvider
@@ -47,13 +47,13 @@ module Observ
     # Default option for "no agent selected" state
     # @return [Array<String>] the default option
     def default_option
-      [ "Default Agent", "" ]
+      ["Default Agent", ""]
     end
 
     # Maps agents to [display_name, identifier] pairs
     # @return [Array<Array<String>>] agent options
     def agent_options
-      agents.map { |agent| [ agent.display_name, agent.agent_identifier ] }
+      agents.map { |agent| [agent.display_name, agent.agent_identifier] }
     end
   end
 end

--- a/app/services/observ/chat_instrumenter.rb
+++ b/app/services/observ/chat_instrumenter.rb
@@ -578,7 +578,7 @@ module Observ
         elsif value.is_a?(Hash)
           truncate_large_hash(value)
         elsif value.is_a?(Array) && value.size > 100
-          value[0..99] + [ "... #{value.size - 100} more items" ]
+          value[0..99] + ["... #{value.size - 100} more items"]
         else
           value
         end

--- a/app/services/observ/dataset_runner_service.rb
+++ b/app/services/observ/dataset_runner_service.rb
@@ -82,7 +82,7 @@ module Observ
           dataset_item_id: run_item.dataset_item_id,
           agent_class: dataset.agent_class
         },
-        tags: [ "dataset_evaluation", dataset.name, dataset_run.name ]
+        tags: ["dataset_evaluation", dataset.name, dataset_run.name]
       )
     end
 

--- a/app/services/observ/evaluator_runner_service.rb
+++ b/app/services/observ/evaluator_runner_service.rb
@@ -42,7 +42,7 @@ module Observ
 
     def default_evaluator_configs
       # Default to exact_match if no config specified
-      [ { "type" => "exact_match" } ]
+      [{ "type" => "exact_match" }]
     end
 
     def build_evaluator(config)

--- a/app/services/observ/evaluators/contains_evaluator.rb
+++ b/app/services/observ/evaluators/contains_evaluator.rb
@@ -32,7 +32,7 @@ module Observ
         when Array
           expected
         when String
-          [ expected ]
+          [expected]
         else
           []
         end

--- a/app/services/observ/guardrail_service.rb
+++ b/app/services/observ/guardrail_service.rb
@@ -48,7 +48,7 @@ module Observ
                      .left_joins(:review_item)
                      .where(observ_review_items: { id: nil })
 
-        sample_size = [ (items.count * percentage / 100.0).ceil, 1 ].max
+        sample_size = [(items.count * percentage / 100.0).ceil, 1].max
 
         items.order("RANDOM()").limit(sample_size).find_each do |item|
           item.enqueue_for_review!(reason: "random_sample", priority: :normal)

--- a/app/services/observ/moderation_guardrail_service.rb
+++ b/app/services/observ/moderation_guardrail_service.rb
@@ -53,7 +53,11 @@ module Observ
       return Result.new(action: :skipped, reason: "already_has_moderation") if has_existing_flags?(trace)
 
       with_observability do |_session|
-        content = extract_trace_content(trace, moderate_input:, moderate_output:)
+        content = extract_trace_content(
+          trace,
+          moderate_input: moderate_input,
+          moderate_output: moderate_output
+        )
         return Result.new(action: :skipped, reason: "no_content") if content.blank?
 
         perform_moderation(trace, content)

--- a/app/services/observ/prompt_manager/caching.rb
+++ b/app/services/observ/prompt_manager/caching.rb
@@ -82,10 +82,10 @@ module Observ
       # @return [Boolean] true if successful
       def invalidate_cache(name:, version: nil)
         keys = if version
-          [ cache_key(name: name, version: version) ]
+          [cache_key(name: name, version: version)]
         else
           # Invalidate all state-based keys for this prompt
-          [ :draft, :production, :archived ].map { |state| cache_key(name: name, state: state) }
+          [:draft, :production, :archived].map { |state| cache_key(name: name, state: state) }
         end
 
         keys.each { |key| Rails.cache.delete(key) }

--- a/app/services/observ/prompt_manager/caching.rb
+++ b/app/services/observ/prompt_manager/caching.rb
@@ -89,6 +89,7 @@ module Observ
         end
 
         keys.each { |key| Rails.cache.delete(key) }
+        bump_cache_stamp(name: name)
         Rails.logger.info("Cache invalidated for #{name}#{version ? " v#{version}" : ""}")
 
         true
@@ -119,6 +120,18 @@ module Observ
 
         Rails.logger.info("Cache warming completed: #{results[:success].count} success, #{results[:failed].count} failed")
         results
+      end
+
+      def cache_stamp_key(name:)
+        "#{Observ.config.prompt_cache_namespace}:#{name}:stamp"
+      end
+
+      def cache_stamp(name:)
+        Rails.cache.read(cache_stamp_key(name: name))
+      end
+
+      def bump_cache_stamp(name:)
+        Rails.cache.write(cache_stamp_key(name: name), Time.current.to_f)
       end
 
       # Get list of critical prompts (prompts used by agents)

--- a/app/validators/observ/prompt_config_validator.rb
+++ b/app/validators/observ/prompt_config_validator.rb
@@ -77,7 +77,7 @@ module Observ
           @errors << "#{key} must be a string"
         end
       when :boolean
-        unless [ true, false ].include?(value)
+        unless [true, false].include?(value)
           @errors << "#{key} must be a boolean"
         end
       when :array
@@ -133,7 +133,7 @@ module Observ
     end
 
     def validate_unknown_keys
-      schema_keys = schema.keys.map { |k| [ k.to_s, k.to_sym ] }.flatten
+      schema_keys = schema.keys.map { |k| [k.to_s, k.to_sym] }.flatten
       config_keys = config.keys
 
       unknown_keys = config_keys - schema_keys
@@ -153,11 +153,11 @@ module Observ
 
     def value_with_key(key)
       if config.key?(key.to_s)
-        [ config[key.to_s], key.to_s ]
+        [config[key.to_s], key.to_s]
       elsif config.key?(key.to_sym)
-        [ config[key.to_sym], key.to_sym ]
+        [config[key.to_sym], key.to_sym]
       else
-        [ nil, nil ]
+        [nil, nil]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,22 +7,22 @@ Observ::Engine.routes.draw do
 
   # Chat routes - only available if Chat model exists in host app
   if defined?(::Chat) && ::Chat.respond_to?(:acts_as_chat)
-    resources :chats, only: [ :index, :new, :create, :show ] do
-      resources :messages, only: [ :create ]
+    resources :chats, only: [:index, :new, :create, :show] do
+      resources :messages, only: [:create]
     end
   end
 
-  resources :sessions, only: [ :index, :show ] do
+  resources :sessions, only: [:index, :show] do
     member do
       get :metrics
       get :drawer_test
       get :annotations_drawer
     end
-    resources :annotations, only: [ :index, :create, :destroy ]
-    resources :scores, only: [ :create, :destroy ]
+    resources :annotations, only: [:index, :create, :destroy]
+    resources :scores, only: [:create, :destroy]
   end
 
-  resources :traces, only: [ :index, :show ] do
+  resources :traces, only: [:index, :show] do
     collection do
       get :search
     end
@@ -32,11 +32,11 @@ Observ::Engine.routes.draw do
       get :add_to_dataset_drawer
       post :add_to_dataset
     end
-    resources :annotations, only: [ :index, :create, :destroy ]
-    resources :scores, only: [ :create, :destroy ]
+    resources :annotations, only: [:index, :create, :destroy]
+    resources :scores, only: [:create, :destroy]
   end
 
-  resources :observations, only: [ :index, :show ] do
+  resources :observations, only: [:index, :show] do
     collection do
       get :generations
       get :spans
@@ -47,7 +47,7 @@ Observ::Engine.routes.draw do
   get "annotations/traces", to: "annotations#traces_index", as: :traces_annotations
   get "annotations/export", to: "annotations#export", as: :export_annotations
 
-  resources :reviews, only: [ :index, :show ], controller: "review_queue" do
+  resources :reviews, only: [:index, :show], controller: "review_queue" do
     collection do
       get :sessions
       get :traces
@@ -65,7 +65,7 @@ Observ::Engine.routes.draw do
       get :compare               # Compare versions
     end
 
-    resources :versions, only: [ :show ], controller: "prompt_versions" do
+    resources :versions, only: [:show], controller: "prompt_versions" do
       member do
         post :promote    # draft -> production
         post :demote     # production -> archived
@@ -76,8 +76,8 @@ Observ::Engine.routes.draw do
   end
 
   resources :datasets do
-    resources :items, controller: "dataset_items", except: [ :show ]
-    resources :runs, controller: "dataset_runs", only: [ :index, :show, :new, :create, :destroy ] do
+    resources :items, controller: "dataset_items", except: [:show]
+    resources :runs, controller: "dataset_runs", only: [:index, :show, :new, :create, :destroy] do
       member do
         post :run_evaluators
         get :review

--- a/db/migrate/005_create_observ_prompts.rb
+++ b/db/migrate/005_create_observ_prompts.rb
@@ -12,10 +12,10 @@ class CreateObservPrompts < ActiveRecord::Migration[7.0]
       t.timestamps
 
       # Composite unique index for name + version
-      t.index [ :name, :version ], unique: true
+      t.index [:name, :version], unique: true
 
       # Index for state queries (e.g., find all production prompts)
-      t.index [ :name, :state ]
+      t.index [:name, :state]
     end
   end
 end

--- a/db/migrate/011_create_observ_dataset_items.rb
+++ b/db/migrate/011_create_observ_dataset_items.rb
@@ -11,7 +11,7 @@ class CreateObservDatasetItems < ActiveRecord::Migration[7.0]
       t.references :source_trace, foreign_key: { to_table: :observ_traces }
       t.timestamps
 
-      t.index [ :dataset_id, :status ]
+      t.index [:dataset_id, :status]
     end
   end
 end

--- a/db/migrate/012_create_observ_dataset_runs.rb
+++ b/db/migrate/012_create_observ_dataset_runs.rb
@@ -15,8 +15,8 @@ class CreateObservDatasetRuns < ActiveRecord::Migration[7.0]
       t.integer :total_tokens, default: 0
       t.timestamps
 
-      t.index [ :dataset_id, :name ], unique: true
-      t.index [ :dataset_id, :status ]
+      t.index [:dataset_id, :name], unique: true
+      t.index [:dataset_id, :status]
     end
   end
 end

--- a/db/migrate/013_create_observ_dataset_run_items.rb
+++ b/db/migrate/013_create_observ_dataset_run_items.rb
@@ -10,7 +10,7 @@ class CreateObservDatasetRunItems < ActiveRecord::Migration[7.0]
       t.text :error
       t.timestamps
 
-      t.index [ :dataset_run_id, :dataset_item_id ], unique: true, name: "idx_run_items_on_run_and_item"
+      t.index [:dataset_run_id, :dataset_item_id], unique: true, name: "idx_run_items_on_run_and_item"
     end
   end
 end

--- a/db/migrate/014_create_observ_scores.rb
+++ b/db/migrate/014_create_observ_scores.rb
@@ -18,8 +18,8 @@ class CreateObservScores < ActiveRecord::Migration[7.0]
 
       t.timestamps
 
-      t.index [ :dataset_run_item_id, :name, :source ], unique: true, name: "idx_scores_on_run_item_name_source"
-      t.index [ :trace_id, :name ]
+      t.index [:dataset_run_item_id, :name, :source], unique: true, name: "idx_scores_on_run_item_name_source"
+      t.index [:trace_id, :name]
       t.index :name
     end
   end

--- a/db/migrate/015_refactor_scores_to_polymorphic.rb
+++ b/db/migrate/015_refactor_scores_to_polymorphic.rb
@@ -19,8 +19,8 @@ class RefactorScoresToPolymorphic < ActiveRecord::Migration[7.0]
     remove_column :observ_scores, :trace_id, :bigint
 
     # Add new indexes
-    add_index :observ_scores, [ :scoreable_type, :scoreable_id ]
-    add_index :observ_scores, [ :scoreable_type, :scoreable_id, :name, :source ],
+    add_index :observ_scores, [:scoreable_type, :scoreable_id]
+    add_index :observ_scores, [:scoreable_type, :scoreable_id, :name, :source],
               unique: true,
               name: "idx_scores_unique_on_scoreable_name_source"
   end

--- a/db/migrate/016_create_observ_review_items.rb
+++ b/db/migrate/016_create_observ_review_items.rb
@@ -17,8 +17,8 @@ class CreateObservReviewItems < ActiveRecord::Migration[7.0]
 
       t.timestamps
 
-      t.index [ :reviewable_type, :reviewable_id ], unique: true, name: "idx_review_items_on_reviewable"
-      t.index [ :status, :priority, :created_at ], name: "idx_review_items_on_status_priority_created"
+      t.index [:reviewable_type, :reviewable_id], unique: true, name: "idx_review_items_on_reviewable"
+      t.index [:status, :priority, :created_at], name: "idx_review_items_on_status_priority_created"
       t.index :status
     end
   end

--- a/lib/tasks/observ_tasks.rake
+++ b/lib/tasks/observ_tasks.rake
@@ -11,7 +11,7 @@ namespace :observ do
     rails observ:sync_assets[app/javascript/stylesheets/observ]
     rails observ:sync_assets[app/assets/stylesheets/observ,app/javascript/controllers/observ]
   "
-  task :sync_assets, [ :styles_dest, :js_dest ] => :environment do |t, args|
+  task :sync_assets, [:styles_dest, :js_dest] => :environment do |t, args|
     require "observ/asset_installer"
 
     # Get the observ gem root (this task is in observ/lib/tasks)
@@ -46,7 +46,7 @@ namespace :observ do
     rails observ:install_assets[app/javascript/stylesheets/observ]
     rails observ:install_assets[app/assets/stylesheets/observ,app/javascript/controllers/observ]
   "
-  task :install_assets, [ :styles_dest, :js_dest ] => :environment do |t, args|
+  task :install_assets, [:styles_dest, :js_dest] => :environment do |t, args|
     require "observ/asset_installer"
 
     # Get the observ gem root

--- a/rubyllm-observ.gemspec
+++ b/rubyllm-observ.gemspec
@@ -3,8 +3,8 @@ require_relative "lib/observ/version"
 Gem::Specification.new do |spec|
   spec.name        = "rubyllm-observ"
   spec.version     = Observ::VERSION
-  spec.authors     = [ "Franck D'agostini" ]
-  spec.email       = [ "franck.dagostini@gmail.com" ]
+  spec.authors     = ["Franck D'agostini"]
+  spec.email       = ["franck.dagostini@gmail.com"]
   spec.homepage    = "https://github.com/franck/observ"
   spec.summary     = "Rails observability engine for LLM applications"
   spec.description = "A Rails engine providing comprehensive observability for LLM-powered applications. Features include session tracking, trace analysis, prompt management, cost monitoring, and optional chat/agent testing UI (with RubyLLM integration)."

--- a/rubyllm-observ.gemspec
+++ b/rubyllm-observ.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "shoulda-matchers", "~> 6.0"
   spec.add_development_dependency "faker", "~> 3.0"
   spec.add_development_dependency "capybara", "~> 3.0"
-  spec.add_development_dependency "sqlite3", "~> 1.4"
+  spec.add_development_dependency "sqlite3", "~> 2.7"
   spec.add_development_dependency "turbo-rails", "~> 2.0"
 end

--- a/spec/factories/chats.rb
+++ b/spec/factories/chats.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
   factory :chat do
     sequence(:title) { |n| "Chat #{n}" }
     agent_class_name { "DummyAgent" }
-
   end
 end

--- a/spec/factories/observ/observ_annotations.rb
+++ b/spec/factories/observ/observ_annotations.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     tags { [] }
 
     trait :with_tags do
-      tags { [ "important", "review" ] }
+      tags { ["important", "review"] }
     end
   end
 end

--- a/spec/factories/observ/observ_observations.rb
+++ b/spec/factories/observ/observ_observations.rb
@@ -234,7 +234,7 @@ FactoryBot.define do
               'self-harm' => 0.001,
               'violence' => 0.002
             },
-            flagged_categories: ['hate', 'harassment']
+            flagged_categories: [ 'hate', 'harassment' ]
           }
         end
       end
@@ -259,7 +259,7 @@ FactoryBot.define do
               'violence' => 0.92,
               'violence/graphic' => 0.88
             },
-            flagged_categories: ['violence', 'violence/graphic']
+            flagged_categories: [ 'violence', 'violence/graphic' ]
           }
         end
       end

--- a/spec/factories/observ/observ_observations.rb
+++ b/spec/factories/observ/observ_observations.rb
@@ -89,7 +89,7 @@ FactoryBot.define do
       end
 
       trait :batch do
-        input { [ 'text 1', 'text 2', 'text 3' ].to_json }
+        input { ['text 1', 'text 2', 'text 3'].to_json }
         usage { { input_tokens: 30, total_tokens: 30 } }
         metadata { { batch_size: 3, dimensions: 1536, vectors_count: 3 } }
       end
@@ -234,7 +234,7 @@ FactoryBot.define do
               'self-harm' => 0.001,
               'violence' => 0.002
             },
-            flagged_categories: [ 'hate', 'harassment' ]
+            flagged_categories: ['hate', 'harassment']
           }
         end
       end
@@ -259,7 +259,7 @@ FactoryBot.define do
               'violence' => 0.92,
               'violence/graphic' => 0.88
             },
-            flagged_categories: [ 'violence', 'violence/graphic' ]
+            flagged_categories: ['violence', 'violence/graphic']
           }
         end
       end

--- a/spec/factories/observ/observ_prompts.rb
+++ b/spec/factories/observ/observ_prompts.rb
@@ -67,7 +67,7 @@ FactoryBot.define do
           top_p: 0.95,
           frequency_penalty: 0.5,
           presence_penalty: 0.3,
-          stop_sequences: [ "STOP", "END" ]
+          stop_sequences: ["STOP", "END"]
         }
       }
     end

--- a/spec/helpers/observ/chats_helper_spec.rb
+++ b/spec/helpers/observ/chats_helper_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Observ::ChatsHelper, type: :helper do
     it 'includes default option as first element' do
       options = helper.agent_select_options
 
-      expect(options.first).to eq([ "Default Agent", "" ])
+      expect(options.first).to eq(["Default Agent", ""])
     end
 
     it 'delegates to AgentSelectionService' do
-      mock_options = [ [ "Default Agent", "" ], [ "Test", "TestAgent" ] ]
+      mock_options = [["Default Agent", ""], ["Test", "TestAgent"]]
 
       allow(Observ::AgentSelectionService).to receive(:options).and_return(mock_options)
 

--- a/spec/helpers/observ/prompts_helper_spec.rb
+++ b/spec/helpers/observ/prompts_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Observ::PromptsHelper, type: :helper do
         model1 = double('Model', provider: 'openai', display_name: 'GPT-4o', id: 'gpt-4o')
         model2 = double('Model', provider: 'openai', display_name: 'GPT-4o Mini', id: 'gpt-4o-mini')
         model3 = double('Model', provider: 'anthropic', display_name: 'Claude 3.5 Sonnet', id: 'claude-3-5-sonnet')
-        models_collection = double('ModelsCollection', chat_models: [ model1, model2, model3 ])
+        models_collection = double('ModelsCollection', chat_models: [model1, model2, model3])
 
         stub_const('RubyLLM', double('RubyLLM', models: models_collection))
         allow(RubyLLM).to receive(:respond_to?).with(:models).and_return(true)
@@ -31,7 +31,7 @@ RSpec.describe Observ::PromptsHelper, type: :helper do
         result = helper.chat_model_options_grouped
 
         anthropic_models = result.find { |p, _| p == 'Anthropic' }[1]
-        expect(anthropic_models).to include([ 'Claude 3.5 Sonnet', 'claude-3-5-sonnet' ])
+        expect(anthropic_models).to include(['Claude 3.5 Sonnet', 'claude-3-5-sonnet'])
       end
 
       it 'sorts models by display name within each provider' do

--- a/spec/integration/prompt_manager_integration_spec.rb
+++ b/spec/integration/prompt_manager_integration_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "PromptManager Integration" do
           config: {
             "model" => "gpt-4",
             "temperature" => "0.7",
-            "stop" => [ "END", "STOP" ]
+            "stop" => ["END", "STOP"]
           }
         )
 
@@ -198,7 +198,7 @@ RSpec.describe "PromptManager Integration" do
         expect(params[:temperature]).to be_a(Float)
 
         # Non-numeric values should be preserved
-        expect(params[:stop]).to eq([ "END", "STOP" ])
+        expect(params[:stop]).to eq(["END", "STOP"])
         expect(params[:stop]).to be_a(Array)
       end
     end

--- a/spec/jobs/observ/moderation_guardrail_job_spec.rb
+++ b/spec/jobs/observ/moderation_guardrail_job_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Observ::ModerationGuardrailJob, type: :job do
 
     it "enqueues sessions matching agent types" do
       expect {
-        described_class.enqueue_for_agent_types([ "chat_support" ])
+        described_class.enqueue_for_agent_types(["chat_support"])
       }.to have_enqueued_job(described_class).exactly(2).times
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Observ::ModerationGuardrailJob, type: :job do
       create(:observ_session, metadata: { "agent_type" => "chat_support" }, created_at: 2.hours.ago)
 
       expect {
-        described_class.enqueue_for_agent_types([ "chat_support" ], since: 1.hour.ago)
+        described_class.enqueue_for_agent_types(["chat_support"], since: 1.hour.ago)
       }.to have_enqueued_job(described_class).exactly(2).times
     end
   end

--- a/spec/jobs/observ/moderation_guardrail_job_spec.rb
+++ b/spec/jobs/observ/moderation_guardrail_job_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Observ::ModerationGuardrailJob, type: :job do
 
     it "enqueues sessions matching agent types" do
       expect {
-        described_class.enqueue_for_agent_types(["chat_support"])
+        described_class.enqueue_for_agent_types([ "chat_support" ])
       }.to have_enqueued_job(described_class).exactly(2).times
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Observ::ModerationGuardrailJob, type: :job do
       create(:observ_session, metadata: { "agent_type" => "chat_support" }, created_at: 2.hours.ago)
 
       expect {
-        described_class.enqueue_for_agent_types(["chat_support"], since: 1.hour.ago)
+        described_class.enqueue_for_agent_types([ "chat_support" ], since: 1.hour.ago)
       }.to have_enqueued_job(described_class).exactly(2).times
     end
   end

--- a/spec/lib/observ/engine_spec.rb
+++ b/spec/lib/observ/engine_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Observ::Engine do
       it "can warm cache" do
         create(:observ_prompt, :production, name: "warm-test")
 
-        result = Observ::PromptManager.warm_cache([ "warm-test" ])
+        result = Observ::PromptManager.warm_cache(["warm-test"])
         expect(result).to have_key(:success)
         expect(result).to have_key(:failed)
         expect(result[:success]).to include("warm-test")
@@ -97,7 +97,7 @@ RSpec.describe Observ::Engine do
 
         versions = Observ::PromptManager.versions(name: "versions-test")
         expect(versions.count).to eq(2)
-        expect(versions.map(&:version)).to eq([ 2, 1 ])
+        expect(versions.map(&:version)).to eq([2, 1])
       end
 
       it "can promote drafts" do

--- a/spec/models/concerns/observ/prompt_management_version_override_spec.rb
+++ b/spec/models/concerns/observ/prompt_management_version_override_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe Observ::PromptManagement, "version override" do
       system_prompt = TestAgent.system_prompt
       expect(system_prompt).to eq("Production prompt v1")
     end
+
+    it "refreshes memoized prompt when production is promoted" do
+      TestAgent.reset_prompt_cache!
+
+      first_prompt = TestAgent.system_prompt
+      expect(first_prompt).to eq("Production prompt v1")
+
+      prompt_v2 = Observ::Prompt.find_by!(name: "test-prompt", version: 2)
+      prompt_v2.promote!
+
+      refreshed_prompt = TestAgent.system_prompt
+      expect(refreshed_prompt).to eq("Draft prompt v2")
+    end
   end
 
   describe ".model with version override" do

--- a/spec/models/observ/embedding_spec.rb
+++ b/spec/models/observ/embedding_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Observ::Embedding, type: :model do
     end
 
     it 'converts array input to JSON' do
-      embedding.set_input([ 'text 1', 'text 2' ])
+      embedding.set_input(['text 1', 'text 2'])
       expect(embedding.input).to be_a(String)
-      expect(JSON.parse(embedding.input)).to eq([ 'text 1', 'text 2' ])
+      expect(JSON.parse(embedding.input)).to eq(['text 1', 'text 2'])
     end
   end
 

--- a/spec/models/observ/generation_spec.rb
+++ b/spec/models/observ/generation_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Observ::Generation, type: :model do
     end
 
     it 'sets messages when provided' do
-      messages = [ { role: 'user', content: 'hello' } ]
+      messages = [{ role: 'user', content: 'hello' }]
       generation.set_input('test', messages: messages)
-      expect(generation.messages).to eq([ { 'role' => 'user', 'content' => 'hello' } ])
+      expect(generation.messages).to eq([{ 'role' => 'user', 'content' => 'hello' }])
     end
   end
 

--- a/spec/models/observ/moderation_spec.rb
+++ b/spec/models/observ/moderation_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Observ::Moderation, type: :model do
 
   describe '#flagged_categories' do
     it 'returns flagged_categories from metadata' do
-      flagged = ['hate', 'harassment']
+      flagged = [ 'hate', 'harassment' ]
       moderation = create(:observ_moderation, metadata: { flagged_categories: flagged })
       expect(moderation.flagged_categories).to eq(flagged)
     end

--- a/spec/models/observ/moderation_spec.rb
+++ b/spec/models/observ/moderation_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Observ::Moderation, type: :model do
 
   describe '#flagged_categories' do
     it 'returns flagged_categories from metadata' do
-      flagged = [ 'hate', 'harassment' ]
+      flagged = ['hate', 'harassment']
       moderation = create(:observ_moderation, metadata: { flagged_categories: flagged })
       expect(moderation.flagged_categories).to eq(flagged)
     end

--- a/spec/models/observ/prompt_spec.rb
+++ b/spec/models/observ/prompt_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Observ::Prompt, type: :model do
       end
 
       it "renders normal section when array has items" do
-        result = prompt.compile(items: [ { count: 3 } ], count: 3)
+        result = prompt.compile(items: [{ count: 3 }], count: 3)
         expect(result).to include("You have 3 items.")
       end
     end
@@ -302,7 +302,7 @@ RSpec.describe Observ::Prompt, type: :model do
 
       it "validates successfully when all variables provided" do
         result = prompt.compile_with_validation(
-          items: [ { name: "Item", price: "10.00" } ],
+          items: [{ name: "Item", price: "10.00" }],
           total: "10.00"
         )
         expect(result).to include("- Item: $10.00")
@@ -561,7 +561,7 @@ RSpec.describe Observ::Prompt, type: :model do
       end
 
       it "accepts valid stop_sequences" do
-        prompt = build(:observ_prompt, config: { stop_sequences: [ "STOP", "END" ] })
+        prompt = build(:observ_prompt, config: { stop_sequences: ["STOP", "END"] })
         expect(prompt).to be_valid
       end
 
@@ -658,7 +658,7 @@ RSpec.describe Observ::Prompt, type: :model do
       end
 
       it "rejects invalid array items in stop_sequences" do
-        prompt = build(:observ_prompt, config: { stop_sequences: [ "STOP", 123 ] })
+        prompt = build(:observ_prompt, config: { stop_sequences: ["STOP", 123] })
         expect(prompt).not_to be_valid
         expect(prompt.errors[:config]).to include("stop_sequences[1] must be a string")
       end

--- a/spec/models/observ/review_item_spec.rb
+++ b/spec/models/observ/review_item_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Observ::ReviewItem, type: :model do
       let!(:normal_item) { create(:observ_review_item, :normal_priority) }
 
       it "orders by priority desc, created_at asc" do
-        items = described_class.by_priority.where(id: [ critical_item.id, high_item.id, normal_item.id ])
+        items = described_class.by_priority.where(id: [critical_item.id, high_item.id, normal_item.id])
         expect(items.first).to eq(critical_item)
         expect(items.second).to eq(high_item)
         expect(items.third).to eq(normal_item)

--- a/spec/models/observ/session_spec.rb
+++ b/spec/models/observ/session_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Observ::Session, type: :model do
         name: 'chat.ask',
         input: 'Hello world',
         metadata: { phase: 'testing' },
-        tags: [ 'test' ]
+        tags: ['test']
       )
 
       expect(trace.name).to eq('chat.ask')
       expect(trace.input).to eq('Hello world')
       expect(trace.metadata).to eq({ 'phase' => 'testing' })
-      expect(trace.tags).to eq([ 'test' ])
+      expect(trace.tags).to eq(['test'])
       expect(trace.user_id).to eq(session.user_id)
     end
 

--- a/spec/models/observ/span_spec.rb
+++ b/spec/models/observ/span_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Observ::Span, type: :model do
     end
 
     it 'converts hash output to JSON' do
-      span.finalize(output: { status: 'ok', data: [ 1, 2, 3 ] })
+      span.finalize(output: { status: 'ok', data: [1, 2, 3] })
       expect(span.output).to be_a(String)
-      expect(JSON.parse(span.output)).to eq({ 'status' => 'ok', 'data' => [ 1, 2, 3 ] })
+      expect(JSON.parse(span.output)).to eq({ 'status' => 'ok', 'data' => [1, 2, 3] })
     end
   end
 

--- a/spec/presenters/observ/agent_select_presenter_spec.rb
+++ b/spec/presenters/observ/agent_select_presenter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Observ::AgentSelectPresenter do
   describe '#initialize' do
     it 'accepts agents via dependency injection' do
-      mock_agents = [ double(display_name: 'Test', agent_identifier: 'Test') ]
+      mock_agents = [double(display_name: 'Test', agent_identifier: 'Test')]
       presenter = described_class.new(agents: mock_agents)
 
       expect(presenter.agents).to eq(mock_agents)
@@ -22,7 +22,7 @@ RSpec.describe Observ::AgentSelectPresenter do
       mock_agents = []
       presenter = described_class.new(agents: mock_agents)
 
-      expect(presenter.options.first).to eq([ 'Default Agent', '' ])
+      expect(presenter.options.first).to eq(['Default Agent', ''])
     end
 
     it 'formats injected agents correctly' do
@@ -35,9 +35,9 @@ RSpec.describe Observ::AgentSelectPresenter do
       options = presenter.options
 
       expect(options).to eq([
-        [ 'Default Agent', '' ],
-        [ 'Agent One', 'AgentOne' ],
-        [ 'Agent Two', 'AgentTwo' ]
+        ['Default Agent', ''],
+        ['Agent One', 'AgentOne'],
+        ['Agent Two', 'AgentTwo']
       ])
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Observ::AgentSelectPresenter do
 
       options = presenter.options
 
-      expect(options.first).to eq([ 'Default Agent', '' ])
+      expect(options.first).to eq(['Default Agent', ''])
       expect(options.count).to eq(agents.count + 1)
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe Observ::AgentSelectPresenter do
       options = described_class.options
 
       expect(options).to be_an(Array)
-      expect(options.first).to eq([ 'Default Agent', '' ])
+      expect(options.first).to eq(['Default Agent', ''])
     end
 
     it 'accepts optional agents parameter' do
@@ -68,8 +68,8 @@ RSpec.describe Observ::AgentSelectPresenter do
       options = described_class.options(agents: mock_agents)
 
       expect(options).to eq([
-        [ 'Default Agent', '' ],
-        [ 'Mock', 'Mock' ]
+        ['Default Agent', ''],
+        ['Mock', 'Mock']
       ])
     end
   end

--- a/spec/services/observ/agent_selection_service_spec.rb
+++ b/spec/services/observ/agent_selection_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Observ::AgentSelectionService do
     it 'includes default option as first element' do
       options = described_class.options
 
-      expect(options.first).to eq([ "Default Agent", "" ])
+      expect(options.first).to eq(["Default Agent", ""])
     end
 
     it 'includes agent options after default' do

--- a/spec/services/observ/chat_instrumenter_spec.rb
+++ b/spec/services/observ/chat_instrumenter_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Observ::ChatInstrumenter do
 
     describe '#format_input' do
       it 'formats text message with attachments' do
-        input = instrumenter.send(:format_input, 'hello', [ 'file.txt' ])
+        input = instrumenter.send(:format_input, 'hello', ['file.txt'])
         expect(input[:text]).to eq('hello')
         expect(input[:attachments]).to be_an(Array)
         expect(input[:attachments].first[:path]).to eq('file.txt')
@@ -240,33 +240,33 @@ RSpec.describe Observ::ChatInstrumenter do
           msg1 = double('Message', role: :user)
           msg2 = double('Message', role: :assistant)
           msg3 = double('Message', role: 'user') # String role
-          messages = [ msg1, msg2, msg3 ]
+          messages = [msg1, msg2, msg3]
 
           result = instrumenter.send(:find_messages_by_role, messages, :user)
-          expect(result).to eq([ msg1, msg3 ])
+          expect(result).to eq([msg1, msg3])
         end
 
         it 'handles symbol role parameter matching string roles' do
           msg1 = double('Message', role: 'assistant')
           msg2 = double('Message', role: :assistant)
-          messages = [ msg1, msg2 ]
+          messages = [msg1, msg2]
 
           result = instrumenter.send(:find_messages_by_role, messages, :assistant)
-          expect(result).to eq([ msg1, msg2 ])
+          expect(result).to eq([msg1, msg2])
         end
 
         it 'handles string role parameter' do
           msg1 = double('Message', role: :user)
           msg2 = double('Message', role: 'user')
-          messages = [ msg1, msg2 ]
+          messages = [msg1, msg2]
 
           result = instrumenter.send(:find_messages_by_role, messages, 'user')
-          expect(result).to eq([ msg1, msg2 ])
+          expect(result).to eq([msg1, msg2])
         end
 
         it 'returns empty array when no messages match' do
           msg1 = double('Message', role: :assistant)
-          messages = [ msg1 ]
+          messages = [msg1]
 
           result = instrumenter.send(:find_messages_by_role, messages, :user)
           expect(result).to eq([])
@@ -279,14 +279,14 @@ RSpec.describe Observ::ChatInstrumenter do
           # but the actual .where call fails (e.g., some proxy or edge case)
           msg1 = double('Message', role: :user)
           msg2 = double('Message', role: :assistant)
-          messages = [ msg1, msg2 ]
+          messages = [msg1, msg2]
 
           # Make the array appear to respond to :where but fail when called
           allow(messages).to receive(:respond_to?).and_call_original
           allow(messages).to receive(:respond_to?).with(:where).and_return(true)
 
           result = instrumenter.send(:find_messages_by_role, messages, :user)
-          expect(result).to eq([ msg1 ])
+          expect(result).to eq([msg1])
         end
 
         it 'handles edge case where where returns non-chainable result' do
@@ -300,10 +300,10 @@ RSpec.describe Observ::ChatInstrumenter do
               return true if method == :where
               super
             end
-          end.new([ msg1, msg2 ])
+          end.new([msg1, msg2])
 
           result = instrumenter.send(:find_messages_by_role, messages, :user)
-          expect(result).to eq([ msg1 ])
+          expect(result).to eq([msg1])
         end
       end
     end
@@ -344,7 +344,7 @@ RSpec.describe Observ::ChatInstrumenter do
           msg1 = message_class.new(role: :user, id: 111)
           msg2 = message_class.new(role: :assistant, id: 456)
           msg3 = message_class.new(role: :assistant, id: 789)
-          messages = [ msg1, msg2, msg3 ]
+          messages = [msg1, msg2, msg3]
 
           chat_instance = double('Chat')
           allow(chat_instance).to receive(:respond_to?).with(:messages).and_return(true)
@@ -360,7 +360,7 @@ RSpec.describe Observ::ChatInstrumenter do
           # Use a struct without id field
           msg_class_no_id = Struct.new(:role, keyword_init: true)
           msg1 = msg_class_no_id.new(role: :assistant)
-          messages = [ msg1 ]
+          messages = [msg1]
 
           chat_instance = double('Chat')
           allow(chat_instance).to receive(:respond_to?).with(:messages).and_return(true)
@@ -374,7 +374,7 @@ RSpec.describe Observ::ChatInstrumenter do
 
         it 'does not update trace when message id is nil' do
           msg1 = message_class.new(role: :assistant, id: nil)
-          messages = [ msg1 ]
+          messages = [msg1]
 
           chat_instance = double('Chat')
           allow(chat_instance).to receive(:respond_to?).with(:messages).and_return(true)
@@ -397,7 +397,7 @@ RSpec.describe Observ::ChatInstrumenter do
               return true if method == :where
               super
             end
-          end.new([ msg1 ])
+          end.new([msg1])
 
           chat_instance = double('Chat')
           allow(chat_instance).to receive(:respond_to?).with(:messages).and_return(true)

--- a/spec/services/observ/embedding_instrumenter_spec.rb
+++ b/spec/services/observ/embedding_instrumenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Observ::EmbeddingInstrumenter do
   let(:mock_batch_embedding_result) do
     double(
       'BatchEmbeddingResult',
-      vectors: [ Array.new(1536) { rand }, Array.new(1536) { rand }, Array.new(1536) { rand } ],
+      vectors: [Array.new(1536) { rand }, Array.new(1536) { rand }, Array.new(1536) { rand }],
       model: 'text-embedding-3-small',
       input_tokens: 30
     )
@@ -160,19 +160,19 @@ RSpec.describe Observ::EmbeddingInstrumenter do
     end
 
     it 'records batch size' do
-      RubyLLM.embed([ "Text 1", "Text 2", "Text 3" ])
+      RubyLLM.embed(["Text 1", "Text 2", "Text 3"])
       embedding = session.traces.last.embeddings.first
       expect(embedding.batch_size).to eq(3)
     end
 
     it 'records vectors count' do
-      RubyLLM.embed([ "Text 1", "Text 2", "Text 3" ])
+      RubyLLM.embed(["Text 1", "Text 2", "Text 3"])
       embedding = session.traces.last.embeddings.first
       expect(embedding.vectors_count).to eq(3)
     end
 
     it 'records correct input tokens for batch' do
-      RubyLLM.embed([ "Text 1", "Text 2", "Text 3" ])
+      RubyLLM.embed(["Text 1", "Text 2", "Text 3"])
       embedding = session.traces.last.embeddings.first
       expect(embedding.input_tokens).to eq(30)
     end

--- a/spec/services/observ/evaluator_runner_service_spec.rb
+++ b/spec/services/observ/evaluator_runner_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Observ::EvaluatorRunnerService do
       let(:configs) do
         [
           { "type" => "exact_match" },
-          { "type" => "contains", "keywords" => [ "expected" ] }
+          { "type" => "contains", "keywords" => ["expected"] }
         ]
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Observ::EvaluatorRunnerService do
       let(:json_dataset_item) { create(:observ_dataset_item, dataset: dataset, expected_output: { key: "value" }) }
       let(:json_trace) { create(:observ_trace, output: '{"key": "value", "extra": "data"}') }
       let!(:json_run_item) { create(:observ_dataset_run_item, dataset_run: dataset_run, dataset_item: json_dataset_item, trace: json_trace) }
-      let(:configs) { [ { "type" => "json_structure" } ] }
+      let(:configs) { [{ "type" => "json_structure" }] }
 
       it "runs json_structure evaluator" do
         service = described_class.new(dataset_run, evaluator_configs: configs)
@@ -86,7 +86,7 @@ RSpec.describe Observ::EvaluatorRunnerService do
     end
 
     context "with invalid evaluator type" do
-      let(:configs) { [ { "type" => "non_existent" } ] }
+      let(:configs) { [{ "type" => "non_existent" }] }
 
       it "skips unknown evaluator types without error" do
         service = described_class.new(dataset_run, evaluator_configs: configs)

--- a/spec/services/observ/moderation_guardrail_service_spec.rb
+++ b/spec/services/observ/moderation_guardrail_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Observ::ModerationGuardrailService do
     double(
       "ModerationResult",
       flagged?: true,
-      flagged_categories: [ "hate", "harassment" ],
+      flagged_categories: ["hate", "harassment"],
       category_scores: { "hate" => 0.95, "harassment" => 0.87, "violence" => 0.1 },
       categories: { "hate" => true, "harassment" => true },
       model: "omni-moderation-latest",
@@ -116,7 +116,7 @@ RSpec.describe Observ::ModerationGuardrailService do
 
       it "includes flagged categories in details" do
         result = service.evaluate_trace(trace)
-        expect(result.details[:flagged_categories]).to eq([ "hate", "harassment" ])
+        expect(result.details[:flagged_categories]).to eq(["hate", "harassment"])
       end
 
       it "sets review item reason to content_moderation" do
@@ -142,7 +142,7 @@ RSpec.describe Observ::ModerationGuardrailService do
         double(
           "ModerationResult",
           flagged?: true,
-          flagged_categories: [ "sexual/minors" ],
+          flagged_categories: ["sexual/minors"],
           category_scores: { "sexual/minors" => 0.99 },
           categories: { "sexual/minors" => true },
           model: "omni-moderation-latest",
@@ -282,7 +282,7 @@ RSpec.describe Observ::ModerationGuardrailService do
         double(
           "ModerationResult",
           flagged?: true,
-          flagged_categories: [ "hate" ],
+          flagged_categories: ["hate"],
           category_scores: { "hate" => 0.95 },
           categories: { "hate" => true },
           model: "omni-moderation-latest",

--- a/spec/services/observ/moderation_guardrail_service_spec.rb
+++ b/spec/services/observ/moderation_guardrail_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Observ::ModerationGuardrailService do
     double(
       "ModerationResult",
       flagged?: true,
-      flagged_categories: ["hate", "harassment"],
+      flagged_categories: [ "hate", "harassment" ],
       category_scores: { "hate" => 0.95, "harassment" => 0.87, "violence" => 0.1 },
       categories: { "hate" => true, "harassment" => true },
       model: "omni-moderation-latest",
@@ -116,7 +116,7 @@ RSpec.describe Observ::ModerationGuardrailService do
 
       it "includes flagged categories in details" do
         result = service.evaluate_trace(trace)
-        expect(result.details[:flagged_categories]).to eq(["hate", "harassment"])
+        expect(result.details[:flagged_categories]).to eq([ "hate", "harassment" ])
       end
 
       it "sets review item reason to content_moderation" do
@@ -142,7 +142,7 @@ RSpec.describe Observ::ModerationGuardrailService do
         double(
           "ModerationResult",
           flagged?: true,
-          flagged_categories: ["sexual/minors"],
+          flagged_categories: [ "sexual/minors" ],
           category_scores: { "sexual/minors" => 0.99 },
           categories: { "sexual/minors" => true },
           model: "omni-moderation-latest",
@@ -282,7 +282,7 @@ RSpec.describe Observ::ModerationGuardrailService do
         double(
           "ModerationResult",
           flagged?: true,
-          flagged_categories: ["hate"],
+          flagged_categories: [ "hate" ],
           category_scores: { "hate" => 0.95 },
           categories: { "hate" => true },
           model: "omni-moderation-latest",

--- a/spec/services/observ/moderation_instrumenter_spec.rb
+++ b/spec/services/observ/moderation_instrumenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Observ::ModerationInstrumenter do
         'self-harm' => 0.001,
         'violence' => 0.002
       },
-      flagged_categories: ['hate', 'harassment'],
+      flagged_categories: [ 'hate', 'harassment' ],
       model: 'omni-moderation-latest',
       id: 'modr-456'
     )
@@ -194,7 +194,7 @@ RSpec.describe Observ::ModerationInstrumenter do
     it 'records flagged_categories' do
       RubyLLM.moderate("Hateful content")
       moderation = session.traces.last.moderations.first
-      expect(moderation.flagged_categories).to eq(['hate', 'harassment'])
+      expect(moderation.flagged_categories).to eq([ 'hate', 'harassment' ])
     end
 
     it 'records high category_scores for flagged categories' do

--- a/spec/services/observ/moderation_instrumenter_spec.rb
+++ b/spec/services/observ/moderation_instrumenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Observ::ModerationInstrumenter do
         'self-harm' => 0.001,
         'violence' => 0.002
       },
-      flagged_categories: [ 'hate', 'harassment' ],
+      flagged_categories: ['hate', 'harassment'],
       model: 'omni-moderation-latest',
       id: 'modr-456'
     )
@@ -194,7 +194,7 @@ RSpec.describe Observ::ModerationInstrumenter do
     it 'records flagged_categories' do
       RubyLLM.moderate("Hateful content")
       moderation = session.traces.last.moderations.first
-      expect(moderation.flagged_categories).to eq([ 'hate', 'harassment' ])
+      expect(moderation.flagged_categories).to eq(['hate', 'harassment'])
     end
 
     it 'records high category_scores for flagged categories' do

--- a/spec/services/observ/prompt_manager_caching_spec.rb
+++ b/spec/services/observ/prompt_manager_caching_spec.rb
@@ -153,9 +153,9 @@ RSpec.describe Observ::PromptManager, '.caching' do
     end
 
     it 'warms cache for specific prompts' do
-      results = described_class.warm_cache([ prompt_name ])
+      results = described_class.warm_cache([prompt_name])
 
-      expect(results[:success]).to eq([ prompt_name ])
+      expect(results[:success]).to eq([prompt_name])
       expect(results[:failed]).to be_empty
     end
 
@@ -163,7 +163,7 @@ RSpec.describe Observ::PromptManager, '.caching' do
       allow(described_class).to receive(:fetch).with(name: prompt_name, state: :production)
         .and_raise(StandardError, "DB error")
 
-      results = described_class.warm_cache([ prompt_name ])
+      results = described_class.warm_cache([prompt_name])
 
       expect(results[:success]).to be_empty
       expect(results[:failed].first[:name]).to eq(prompt_name)

--- a/spec/services/observ/prompt_manager_spec.rb
+++ b/spec/services/observ/prompt_manager_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe Observ::PromptManager do
     let!(:prompt2) { create(:observ_prompt, :production, name: "prompt-2") }
 
     it "fetches multiple prompts and indexes by name" do
-      result = described_class.fetch_all(names: [ "prompt-1", "prompt-2" ])
+      result = described_class.fetch_all(names: ["prompt-1", "prompt-2"])
 
-      expect(result.keys).to match_array([ "prompt-1", "prompt-2" ])
+      expect(result.keys).to match_array(["prompt-1", "prompt-2"])
       expect(result["prompt-1"].id).to eq(prompt1.id)
       expect(result["prompt-2"].id).to eq(prompt2.id)
     end
@@ -63,7 +63,7 @@ RSpec.describe Observ::PromptManager do
 
     it "returns all versions in descending order" do
       versions = described_class.versions(name: "test")
-      expect(versions.map(&:version)).to eq([ 2, 1 ])
+      expect(versions.map(&:version)).to eq([2, 1])
     end
   end
 

--- a/spec/services/observ/trace_text_formatter_spec.rb
+++ b/spec/services/observ/trace_text_formatter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Observ::TraceTextFormatter do
       input: 'What is the capital of France?',
       output: 'The capital of France is Paris.',
       user_id: 'user123',
-      tags: [ 'production', 'chat' ],
+      tags: ['production', 'chat'],
       metadata: { phase: 'conversation', context: 'geography' }
     )
   end
@@ -87,7 +87,7 @@ RSpec.describe Observ::TraceTextFormatter do
           annotatable: trace,
           content: 'This is a good response',
           annotator: 'reviewer',
-          tags: [ 'approved' ]
+          tags: ['approved']
         )
         create(:observ_annotation,
           annotatable: trace,

--- a/spec/validators/observ/prompt_config_validator_spec.rb
+++ b/spec/validators/observ/prompt_config_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Observ::PromptConfigValidator do
       end
 
       it 'returns false and adds error for array config' do
-        validator = described_class.new([ 1, 2, 3 ])
+        validator = described_class.new([1, 2, 3])
         expect(validator.valid?).to be false
         expect(validator.errors).to include("Config must be a Hash")
       end
@@ -67,7 +67,7 @@ RSpec.describe Observ::PromptConfigValidator do
       end
 
       it 'validates correct stop_sequences array' do
-        config = { stop_sequences: [ "STOP", "END" ] }
+        config = { stop_sequences: ["STOP", "END"] }
         validator = described_class.new(config)
         expect(validator.valid?).to be true
         expect(validator.errors).to be_empty
@@ -114,7 +114,7 @@ RSpec.describe Observ::PromptConfigValidator do
           temperature: 0.8,
           max_tokens: 2000,
           top_p: 0.95,
-          stop_sequences: [ "END" ]
+          stop_sequences: ["END"]
         }
         validator = described_class.new(config)
         expect(validator.valid?).to be true
@@ -268,14 +268,14 @@ RSpec.describe Observ::PromptConfigValidator do
 
     context 'with invalid array items' do
       it 'rejects non-string items in stop_sequences' do
-        config = { stop_sequences: [ "STOP", 123, "END" ] }
+        config = { stop_sequences: ["STOP", 123, "END"] }
         validator = described_class.new(config)
         expect(validator.valid?).to be false
         expect(validator.errors).to include("stop_sequences[1] must be a string")
       end
 
       it 'rejects multiple invalid items in stop_sequences' do
-        config = { stop_sequences: [ 123, 456 ] }
+        config = { stop_sequences: [123, 456] }
         validator = described_class.new(config)
         expect(validator.valid?).to be false
         expect(validator.errors).to include("stop_sequences[0] must be a string")


### PR DESCRIPTION
## Summary
- add a per-prompt cache stamp and bump it on prompt cache invalidation
- use the cache stamp to reset memoized system prompts when production changes
- add a regression spec covering promotion-driven refresh